### PR TITLE
simply updated readme to ensure users / testers setup their test node…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The standard NIP-07 signing interface remains unchanged.
 
 ## Installation
 
-This extension is not yet available in the Chrome Web Store, so you will need to install it manually.
+This extension is not yet available in the Chrome Web Store, so you will need to install it manually. Before you load the unpacked Chrome extension, you will need to follow the steps for running the [Test Node / Relay](#running-a-test-node--relay) first.
 
 1. Go to `chrome://extensions`.
 2. Enable "Developer mode" if it is not already enabled.
@@ -57,7 +57,7 @@ npm run start node
 ## Run the test relay:
 npm run start relay
 ## Run both the node and the relay:
-num run start dev
+npm run start dev
 ```
 
 By default, the relay will be listening on port `8002`. You can change this by modifying the start script in `test/scripts/start.ts`.


### PR DESCRIPTION
… before trying to install the frost2x as a Chrome Extension

As discussed with Austin, if you try load the unpacked frost2x chrome extension before you go through the Running a Test Node / Relay section of the readme, you're going to have a bad time. 

I fixed this by making a simple reference in the Installation section of the readme, and fixed the typo (num -> npm) in the Running a Test Node / Relay section. 